### PR TITLE
Remove warning about React alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A hook to use [immer](https://github.com/mweststrate/immer) as a React [hook](https://reactjs.org/docs/hooks-intro.html) to manipulate state.
 
-_Warning: Hooks are currently a React [RFC](https://github.com/reactjs/rfcs/pull/68) and **not ready for production**. Use at minimum `react@16.7.0-alpha.0` to use this package._
-
 # Installation
 
 `npm install use-immer`


### PR DESCRIPTION
Hooks has been released for production use now with React 16.8.0. So there's no need for the warning anymore.