### PR TITLE
fix typings path

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "module": "dist/use-immer.module.js",
   "jsnext:main": "dist/use-immer.module.js",
   "react-native": "dist/use-immer.module.js",
-  "typings": "dist/use-immer.d.ts",
+  "typings": "dist/index.d.ts",
   "source": "src/index.ts",
   "scripts": {
     "build": "microbundle",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import produce, { Draft } from "immer"
 import { useState, useReducer, useMemo } from "react"
 
-type Reducer<S = any, A = any> = (
+export type Reducer<S = any, A = any> = (
   draftState: Draft<S>,
   action: A,
 ) => void | S


### PR DESCRIPTION
I noticed that the typings were pointing to the wrong file and also the `Reducer` type was no longer exported because of the generated declaration file.